### PR TITLE
gate metabase service behind a profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   metabase:
     image: metabase/metabase:latest
+    profiles:
+      - metabase
     container_name: metabase
     hostname: metabase
     volumes:


### PR DESCRIPTION
If you're developing you probably aren't gonna have metabase on, only enable it when `--profile metabase` is passed.